### PR TITLE
fix error: Attempt to recreate a file for type letscode.boot3…QCustomer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,11 +25,10 @@ configurations {
 }
 
 //
-def queryDslOutput = file(new File(projectDir, '/src/generated/'))
+def queryDslOutput = file(new File(projectDir, 'build/generated/sources/annotationProcessor/java/main'))
 sourceSets {
     main {
         java {
-//            srcDirs += ['build/generated/sources/annotationProcessor/java/main']
             srcDirs += queryDslOutput.absolutePath
         }
     }


### PR DESCRIPTION
Obs:
- need to have annotation processors enable (Settings > Build, Execution, Deployment > Compiler > Annotation Processors)
- if you want to have QCustomer.java class generated into /src/main/generated/letscode.boot3.customers, you need to change the properties “Build and run” using IntelliJ IDEA. (Settings > Build, Execution, Deployment > Build Tools > Gradle > Build and run using), else use default Gradle