### PR TITLE
Fix docker compose to use generic mongo image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   mongodb:
-    image: arm64v8/mongo:latest
+    image: mongo:latest
 #    environment:
 #      MONGO_INITDB_DATABASE: database
 #      MONGO_INITDB_ROOT_USERNAME: username


### PR DESCRIPTION
The `arm64v8` image was not working on docker installed on ubuntu and windows.