### PR TITLE
Spring config URL and docker compose fix for user home directory to different OS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,6 @@ services:
       - 9411:9411
 
   mongodb:
-    image: arm64v8/mongo:latest
+    image: mongo:latest
     ports:
       - 27017:27017

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-#spring.config.import=configtree:${HOME}/Desktop/config/
+#spring.config.import=configtree:${user.home}/Desktop/config/
 spring.sql.init.mode=always
 spring.graphql.graphiql.enabled=true
 spring.graphql.path=/graphql


### PR DESCRIPTION
- Used `${user.home}` instead of `${HOME}` to get the home directory.
- The `arm64v8` image was not working on docker installed on ubuntu and windows.